### PR TITLE
Remove Positive Slippage

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,7 @@ import {
 } from 'rxjs/operators';
 import {Quote, SwapData} from './services/1inch.api/1inch.api.dto';
 import {BigNumber} from 'ethers/utils';
-import {bnToNumberSafe} from './utils';
+import {bnToNumberSafe, removePositiveSlippage} from './utils';
 import {EthereumService} from './services/ethereum.service';
 import {environment} from '../environments/environment';
 import {ethers} from 'ethers';
@@ -273,7 +273,7 @@ export class AppComponent implements OnDestroy {
                 const tx: Tx = {
                     to: data.tx.to,
                     value: data.tx.value,
-                    data: data.tx.data,
+                    data: removePositiveSlippage(data.tx.data, data.toToken.address),
                     gasPrice: data.tx.gasPrice
                 };
                 transactions.push(tx);

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -12,6 +12,21 @@ export function bnToNumberSafe(val: BigNumber): number {
   return parseInt(hex, 16);
 }
 
+export function removePositiveSlippage(data: string, toToken: string): string {
+  // 4470bdb947 followed by the sell token seems to indicate the positive slippage capture.
+  // The word after seems to correspond to the "guaranteed" buy amount (if proceeds are higher, 
+  // the difference is captured by the protocol). By setting this amount to max uint we make
+  // sure that no positive slippage is extracted.
+  const regexp = RegExp("4470bdb947000000000000000000000000" + toToken.substring(2,42));
+  const match = data.match(regexp)
+  if (match) {
+    // replace min guaranteed amount
+    const guaranteed_min_amount_section = match.index + 74;
+    return data.substring(0, guaranteed_min_amount_section) + "ff".repeat(32) + data.substring(guaranteed_min_amount_section + 64, data.length)
+  }
+  return data;
+}
+
 export const zeroValueBN = bigNumberify(0);
 
 export class RefreshingReplaySubject<T> extends ReplaySubject<T> {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-    "name": "1inch.exchange",
+    "name": "1inch.exchange (positive slippage removed)",
     "description": "DEX aggregator with the best prices on the market",
     "iconPath": "assets/1inch.png",
     "providedBy": {"name": "1inch corporation", "url": "https://1inch.exchange"}


### PR DESCRIPTION
This PR changes the tx payload to remove the logic that takes positive slippage of any trade which gets a better exchange rate than estimated. This is particularly important for the Safe App because it can take a long time until enough owners have signed the transaction. Therefore positive slippage can be significant.

The app is currently deployed on IPFS under QmctzN78eGtZDut7e2Gc7TaDqZpGnWYFhw22fejAEfoSHu (use https://ipfs.io/ipfs/QmctzN78eGtZDut7e2Gc7TaDqZpGnWYFhw22fejAEfoSHu/ to add to your own Safe)